### PR TITLE
video/audio toggle display button

### DIFF
--- a/src/components/VideoPlayer.jsx
+++ b/src/components/VideoPlayer.jsx
@@ -6,6 +6,7 @@ export const VideoPlayer = () => {
   // https://www.w3schools.com/react/react_forms.asp
   const [playerUrl, setPlayerUrl] = useState("");
   const [inputUrl, setInputUrl] = useState("");
+  const [showVideo, setShowVideo] = useState(true);
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -13,10 +14,27 @@ export const VideoPlayer = () => {
     setInputUrl("");
   };
 
+  const toggleVideo = () => {
+    setShowVideo((prev) => !prev);
+  };
+
+  const videoStyle = {
+    display: showVideo ? "block" : "none",
+  };
+
   return (
     <>
       <div className="flex flex-col item-center">
-        <ReactPlayer className="m-auto h-56 p-2 bg-black" url={playerUrl} />
+        <div style={videoStyle}>
+          <ReactPlayer
+            className="m-auto h-56 p-2 bg-black" 
+            url={playerUrl} 
+            playing={true}
+            controls
+            width="480px"
+            height="270px"
+          />
+        </div>
         <form className="m-auto" onSubmit={handleSubmit}>
           <label>
             Enter a video URL:
@@ -28,6 +46,9 @@ export const VideoPlayer = () => {
             <input type="submit" />
           </label>
         </form>
+        <button onClick={toggleVideo}>
+          {showVideo ? "Switch to Audio" : "Switch to Video"}
+        </button>
       </div>
     </>
   );


### PR DESCRIPTION
Video player component now includes the ability to toggle between displaying a video and playing only audio. Introduces the toggleVideo function, the videoStyle object, configuring the ReactPlayer component, and adding a toggle button.

Changes:

Added the toggleVideo function to handle toggling between video and audio display. Introduced the videoStyle object for controlling the display property. Configured the ReactPlayer component with playing={true}, controls, width="480px", and height="270px". Added a button with the onClick handler to toggle between "Switch to Audio" and "Switch to Video" text.